### PR TITLE
Ajout Dockerfile-Back et bdd gérée par Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM openjdk:21-jdk-slim as build
+
+COPY target/VroomVroomCar.jar /VroomVroomCar.jar
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "/VroomVroomCar.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+services:
+
+  angular-app:
+    build:
+      context: ../VroomVroomCar-front
+    image: angular-app
+    ports:
+      - "4200:4200"
+    depends_on:
+      - springboot-app
+  springboot-app:
+    build:
+      context: .
+    image: springboot-app
+    ports:
+      - "8080:8080"
+    depends_on:
+      - mysql
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3306/vroomvroomcar
+      SPRING_DATASOURCE_USERNAME: root
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+      SPRING_DATASOURCE_PASSWORD: root
+    networks:
+      - app-network
+
+  mysql:
+    image: mysql:5.7
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: vroomvroomcar
+    ports:
+      - "3306:3306"
+    networks:
+      - app-network
+
+networks:
+  app-network:
+    driver: bridge

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 spring.application.name=VroomVroomCar
 spring.profiles.active=env
 
-spring.datasource.url=jdbc:mysql://localhost:3306/vroomvroomcar
+spring.datasource.url=jdbc:mysql://mysql:3306/vroomvroomcar
 spring.datasource.username=root
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 


### PR DESCRIPTION
Pour que le docker actuel marche, il faut avoir les deux dossiers back et front dans le même dossier et utiliser les commandes :
```cmd
docker compose build
docker compose up
```

(On peut aussi ajouter un .sh et un .bat qui font ces deux commandes à notre place)